### PR TITLE
Update the alienfile to build Raylib 5.0

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -5,16 +5,14 @@ plugin 'PkgConfig' => 'raylib';
 
 share {
     plugin Download => (
-        url => 'https://github.com/raysan5/raylib/archive/'
-             . '0d2cfce18edf8016b7ff865aafab25ee7a352507'
-             . '.tar.gz'
+        url => 'https://github.com/raysan5/raylib/archive/refs/tags/5.0.tar.gz'
     );
 
     plugin Extract => 'tar.gz';
     plugin 'Build::CMake';
 
     my @CMAKE_ARGS = (
-        '-DWITH_PIC=ON', '-DSHARED=ON', '-DSTATIC=ON',
+        '-DWITH_PIC=ON', '-DBUILD_SHARED_LIBS=ON',
         '-DBUILD_EXAMPLES=OFF', '-DBUILD_GAMES=OFF',
     );
 


### PR DESCRIPTION
The most recent release of Raylib is version 5.0 with some significant updates and new functions in the API.

This will close #4